### PR TITLE
Make Nitor Nestori achievement line suppressible (default: hidden)

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -66,6 +66,7 @@ export const greeter = async (
     const service = new CongratulationService(
         new AnniversaryService(new EmployeeRepositoryLocalImpl(peopleData)),
         new SlackService(config.slack),
+        process.env["SKIP_NESTORI_ACHIEVEMENT"] !== "false",
     );
 
     await service.congratulate(date, event.sendNow);

--- a/service/CongratulationService.test.ts
+++ b/service/CongratulationService.test.ts
@@ -15,6 +15,13 @@ const anniversaryService = new AnniversaryService(mockRepostitoryService);
 const slackService = new SlackService(new SlackConfiguration("", "", "", true));
 
 const service = new CongratulationService(anniversaryService, slackService);
+// Same service but with the Nestori achievement line enabled (flag off),
+// used to verify the pre-suppression wording.
+const serviceNoSkip = new CongratulationService(
+    anniversaryService,
+    slackService,
+    false,
+);
 
 jest.spyOn(global, "setTimeout").mockImplementation((fn: any) => {
     if (typeof fn === "function") {
@@ -303,7 +310,7 @@ it("Sends messages immediately if sendImmediately=true", async () => {
     );
 });
 
-it("Sends message special message on 5 year nversary", async () => {
+it("Hides the Nitor Nestori achievement line on 5 year nversary by default", async () => {
     const now = new Date("2020-02-06T03:30:00Z");
     //slackService.getChannelUsers = jest.fn(() => Promise.resolve([]));
     slackService.getUsers = jest.fn(() => Promise.resolve([]));
@@ -326,6 +333,41 @@ it("Sends message special message on 5 year nversary", async () => {
     );
 
     await service.congratulate(now, false);
+    const sendTime = new Date("2020-02-06T11:40:00Z");
+    // The employee is still congratulated (message + start-date context line),
+    // but the "Achievement Unlocked: Nitor Nestori!" line is suppressed.
+    expect(slackService.scheduleMessage).toHaveBeenCalledWith(
+        "Congratulations *Erkki Esimerkki* 5 years at Nitor! :tada::palm_tree:",
+        [
+            "Erkki started at Nitor on 6.2.2015 and works now as Senior Architect in Technology.",
+        ],
+        undefined,
+        sendTime,
+    );
+});
+
+it("Shows the Nitor Nestori achievement line on 5 year nversary when flag is off", async () => {
+    const now = new Date("2020-02-06T03:30:00Z");
+    slackService.getUsers = jest.fn(() => Promise.resolve([]));
+    slackService.scheduleMessage = jest.fn((message, contextMessage, now) =>
+        Promise.resolve(),
+    );
+
+    const congratulationDay = new CongratulationDay(now);
+    congratulationDay.employees = [
+        new Employee(
+            "Erkki Esimerkki",
+            "asd@asd.com",
+            [new Presence(new Date("2015-02-06"))],
+            "Senior Architect",
+            "Technology",
+        ),
+    ];
+    anniversaryService.getEmployeesToCongratulateToday = jest.fn(
+        (date: Date, maxPerDay: number) => congratulationDay,
+    );
+
+    await serviceNoSkip.congratulate(now, false);
     const sendTime = new Date("2020-02-06T11:40:00Z");
     expect(slackService.scheduleMessage).toHaveBeenCalledWith(
         "Congratulations *Erkki Esimerkki* 5 years at Nitor! :tada::palm_tree:",

--- a/service/CongratulationService.ts
+++ b/service/CongratulationService.ts
@@ -7,13 +7,16 @@ import { SlackService } from "./SlackService";
 class CongratulationService {
     public anniversaryService: AnniversaryService;
     public slackService: SlackService;
+    public skipNestoriAchievement: boolean;
 
     constructor(
         anniversaryService: AnniversaryService,
         slackService: SlackService,
+        skipNestoriAchievement: boolean = true,
     ) {
         this.anniversaryService = anniversaryService;
         this.slackService = slackService;
+        this.skipNestoriAchievement = skipNestoriAchievement;
     }
 
     public async congratulate(
@@ -98,9 +101,11 @@ class CongratulationService {
         ];
 
         if (yearsAtCompany === 5) {
-            contextMessages.push(
-                "Achievement Unlocked: Nitor Nestori! :palm_tree:",
-            );
+            if (!this.skipNestoriAchievement) {
+                contextMessages.push(
+                    "Achievement Unlocked: Nitor Nestori! :palm_tree:",
+                );
+            }
         } else if (yearsAtCompany === 10) {
             contextMessages.push(
                 "Achievement Unlocked: Nitor Fellow! :palm_tree::palm_tree:",

--- a/terraform/infra/envs/dev/main.tf
+++ b/terraform/infra/envs/dev/main.tf
@@ -5,11 +5,12 @@ module "nversary_notifier" {
   runtime     = "nodejs24.x"
   timeout     = 300
 
-  people_s3_bucket    = var.people_s3_bucket
-  people_s3_key       = var.people_s3_key
-  ssm_parameter_name  = var.ssm_parameter_name
-  artifact_file       = "${path.module}/../../../../build/dev/nversary.zip"
-  schedule_expression = "cron(0 0 31 2 ? *)" // This will never fire, effectively disabling the scheduled execution in the dev environment
-  log_retention_days  = 30
-  slack_dry_run       = var.slack_dry_run
+  people_s3_bucket         = var.people_s3_bucket
+  people_s3_key            = var.people_s3_key
+  ssm_parameter_name       = var.ssm_parameter_name
+  artifact_file            = "${path.module}/../../../../build/dev/nversary.zip"
+  schedule_expression      = "cron(0 0 31 2 ? *)" // This will never fire, effectively disabling the scheduled execution in the dev environment
+  log_retention_days       = 30
+  slack_dry_run            = var.slack_dry_run
+  skip_nestori_achievement = true
 }

--- a/terraform/infra/envs/prod/main.tf
+++ b/terraform/infra/envs/prod/main.tf
@@ -5,11 +5,12 @@ module "nversary_notifier" {
   runtime     = "nodejs24.x"
   timeout     = 300
 
-  people_s3_bucket   = var.people_s3_bucket
-  people_s3_key      = var.people_s3_key
-  ssm_parameter_name = var.ssm_parameter_name
-  artifact_file      = "${path.module}/../../../../build/prod/nversary.zip"
-  schedule_expression = "cron(50 3 * * ? *)"
-  log_retention_days = 30
-  slack_dry_run      = false
+  people_s3_bucket         = var.people_s3_bucket
+  people_s3_key            = var.people_s3_key
+  ssm_parameter_name       = var.ssm_parameter_name
+  artifact_file            = "${path.module}/../../../../build/prod/nversary.zip"
+  schedule_expression      = "cron(50 3 * * ? *)"
+  log_retention_days       = 30
+  slack_dry_run            = false
+  skip_nestori_achievement = true
 }

--- a/terraform/modules/nversary_notifier/main.tf
+++ b/terraform/modules/nversary_notifier/main.tf
@@ -103,15 +103,16 @@ resource "aws_lambda_function" "nversary_notifier" {
   handler       = "handler.greeter"
   timeout       = var.timeout
 
-  filename = var.artifact_file
+  filename         = var.artifact_file
   source_code_hash = filebase64sha256(var.artifact_file)
 
   environment {
     variables = {
-      PEOPLE_S3_BUCKET   = var.people_s3_bucket
-      PEOPLE_S3_KEY      = var.people_s3_key
-      SSM_PARAMETER_NAME = var.ssm_parameter_name
-      SLACK_DRY_RUN      = tostring(var.slack_dry_run)
+      PEOPLE_S3_BUCKET         = var.people_s3_bucket
+      PEOPLE_S3_KEY            = var.people_s3_key
+      SSM_PARAMETER_NAME       = var.ssm_parameter_name
+      SLACK_DRY_RUN            = tostring(var.slack_dry_run)
+      SKIP_NESTORI_ACHIEVEMENT = tostring(var.skip_nestori_achievement)
     }
   }
 

--- a/terraform/modules/nversary_notifier/variables.tf
+++ b/terraform/modules/nversary_notifier/variables.tf
@@ -51,3 +51,9 @@ variable "slack_dry_run" {
   type        = bool
   default     = false
 }
+
+variable "skip_nestori_achievement" {
+  description = "When true, hide the 'Achievement Unlocked: Nitor Nestori!' line on 5-year anniversaries"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
The 5-year anniversary message previously appended an extra context line, "Achievement Unlocked: Nitor Nestori! :palm_tree:". Hide this line by default while still congratulating everyone (message and start-date context line are unchanged), and leave the 10-year "Nitor Fellow" line untouched.

Rather than delete the code, gate it behind a configurable feature flag so it can be re-enabled later, mirroring the existing SLACK_DRY_RUN plumbing:

- CongratulationService: new skipNestoriAchievement constructor param (default true) gating only the Nestori achievement push.
- handler: reads SKIP_NESTORI_ACHIEVEMENT env var (unset = on; only "false" disables).
- terraform: new skip_nestori_achievement module variable (default true) wired to the Lambda env var and set true in dev and prod.
- tests: 5-year test now asserts the line is hidden by default; added a flag-off test proving it reappears.